### PR TITLE
Provide an (optional) space to add a port advertisement override

### DIFF
--- a/core/src/main/scala/com.socrata.curator/DiscoveryConfig.scala
+++ b/core/src/main/scala/com.socrata.curator/DiscoveryConfig.scala
@@ -12,4 +12,5 @@ class DiscoveryConfig(config: Config, root: String) extends ConfigClass(config, 
   val serviceBasePath = getString("service-base-path")
   val name = getString("name")
   val address = getString("address")
+  val port = optionally(getInt("port"))
 }


### PR DESCRIPTION
Next to the (non-optional) space to add a host advertisement override